### PR TITLE
Add new Scenario -  Anomalous Materials

### DIFF
--- a/data/mods/Aftershock/scenarios.json
+++ b/data/mods/Aftershock/scenarios.json
@@ -7,5 +7,13 @@
       "professions": [ "afs_affluent_executive", "afs_wraitheon_executive", "afs_vatgrown_bodyguard" ]
     },
     "ident": "heli_crash"
+  },
+  {
+    "copy-from": "lab_staff",
+    "name": "Challenge - Anomalous Materials",
+    "type": "scenario",
+    "allowed_locs": [  "sloc_lab_finale",  "sloc_ice_lab_finale" ],
+    "professions": [ "afs_planar_frontiersman" ],
+    "ident": "labFreeman"
   }
 ]


### PR DESCRIPTION
Creates a scenario to emulate something akin to the resonance cascade from the game Half Life 1.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary


SUMMARY: Mods "Adds a new lab start scenario to Aftershock, Anomalous Materials"


#### Purpose of change

To give the planar frontiersman profession more of a purpose than just a one off gag within the mod itself, and to allow the player to replicate a specific scenario consistently for play purposes

#### Describe the solution

It simply creates a new scenario that copies from the laboratory start while providing access to the lab finale start

#### Describe alternatives you've considered

Simply adding the planar frontiersman to the lab technician start

#### Testing

I spawned into the game using the random location spawn several times to make sure that the frontiersman/woman will spawn in an ice/normal lab finale

#### Additional context

